### PR TITLE
Refactor documentation to present the repository as the Discovery Server testing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# eProsima Discovery Server
+# eProsima Discovery Server Testing Framework
 
-The [RTPS standard](http://www.omg.org/spec/DDSI-RTPS/2.3) specifies in section 8.5 a non-centralized, distributed,
-simple discovery mechanism. This mechanism was devised to allow interoperability between independent
-vendor-specific implementations but it is not expected to be optimal in every environment.
+This repository hosts the testing framework used to validate the **Discovery Server** discovery mechanism of
+[eProsima Fast DDS](https://fast-dds.docs.eprosima.com/en/latest/).
+
+Discovery Server is a discovery mechanism built into *Fast DDS*, not a separate product.
+Its description, configuration and usage are documented in the
+[Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/discovery/discovery.html).
+Everything in this repository exists to exercise that mechanism and check that it behaves as expected.
 
 ## Commercial support
 
@@ -10,133 +14,94 @@ Looking for commercial support? Write us to info@eprosima.com
 
 Find more about us at [eProsima’s webpage](https://eprosima.com/).
 
-## Overview
-
-There are several scenarios where the simple discovery mechanism is unsuitable, or it just simply cannot be
-applied:
-
-- A high number of endpoint entities are continuously entering and exiting a large network.
-- Networks without multicasting capabilities.
-- WiFi-based communication networks.
-
-In order to cope with the aforementioned issues, the *eProsima Fast DDS* discovery mechanisms are extended with a new
-Discovery Server discovery paradigm.
-This is based on a client-server architecture, i.e. the metatraffic (message exchange among
-DDS DomainParticipants to identify each other) is managed by one or several server DomainParticipants (right figure), as
-opposed to simple discovery (left figure), where metatraffic is exchanged using a message broadcast mechanism like an
-IP multicast protocol.
-Please, refer to
-[Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/discovery/server_client.html) for
-further information about the Discovery Server discovery mechanism.
-
-![discovery diagrams][diagrams]
-
-[diagrams]: resources/images/ds_uml.png
-
-The Discovery Server tool is developed to ease Discovery Server discovery mechanism setup and testing.
-The **Discovery Server tool documentation** can be found
-[here](https://eprosima-discovery-server.readthedocs.io/en/latest/).
-
+-   [Overview](#overview)
 -   [Supported platforms](#supported-platforms)
 -   [Installation Guide](#installation-guide)
--   [Usage](#usage)
--   [Example application](#example-application)
--   [Testing](#testing)
+-   [Running the tests](#running-the-tests)
+-   [Test configuration files](#test-configuration-files)
 -   [Documentation](#documentation)
--   [Getting Help](#getting-help)
+
+## Overview
+
+The framework has two parts:
+
+-   **The `discovery-server` tool**: a C++ executable that reads a single XML configuration file and deploys the
+    DDS entities described in it (servers, clients — super clients among them — publishers and subscribers),
+    creating and destroying them at the times stated in the file.
+    The tool listens to the discovery information received by every participant it creates, stores it in a database,
+    and dumps *snapshots* of that database at the requested time points.
+    A snapshot is the collective knowledge of every deployed participant at a given instant, serialized as XML.
+
+-   **The test suite**: a set of Python scripts (`test/`) that run the tool over each test case, and validate the
+    resulting snapshots against the expected discovery state.
+    Test cases are declared in `test/configuration/tests_params.json`, their XML configurations live in
+    `test/configuration/test_cases`, and the expected results in `test/configuration/test_solutions`.
+    The suite is registered with CTest, so the whole set of scenarios runs with a single `ctest` invocation, and it
+    is the same suite executed by this repository's CI.
+
+Scenarios covered include single and multiple interconnected servers, server redundancy, remote servers, entity
+disposals, lease duration, reconnections, super clients, the `fastdds discovery` CLI tool, the environment variable
+setup, UDP and TCP transports, and XTypes.
 
 ## Supported platforms
 
 * Linux
 * Windows
 
-
 ## Installation Guide
 
-In order to use the Discovery Server tool, it is necessary to have a compatible version of
-[eProsima Fast DDS](https://fast-dds.docs.eprosima.com/en/latest/) installed (over release 3.0.0).
-*Fast DDS* dependencies as tinyxml must be accessible, either because *Fast DDS* was build-installed defining
+Building the framework requires a compatible version of
+[eProsima Fast DDS](https://fast-dds.docs.eprosima.com/en/latest/) (over release 3.0.0).
+See [RELEASE_SUPPORT.md](RELEASE_SUPPORT.md) for the *Fast DDS* version matching each branch of this repository.
+*Fast DDS* dependencies such as tinyxml must be accessible, either because *Fast DDS* was build-installed defining
 `THIRDPARTY=ON|FORCE` or because those libraries have been specifically installed.
-The well known cross-platform tool [colcon](https://colcon.readthedocs.io/en/released/) was chosen to simplify the
-installation of the several mutually dependent [CMake](https://cmake.org/cmake/help/latest/) projects. In order to use
-colcon, [Python3](https://www.python.org/) and [CMake](https://cmake.org/cmake/help/latest/) must be first installed.
-Detailed instructions on how to install the required dependencies can be found in the
-[Discovery Server documentation](https://eprosima-discovery-server.readthedocs.io/en/latest/).
 
-To execute the tests that verify the proper operation of the Discovery Server discovery mechanism, it is necessary
-to install some Python3 modules. These can be installed using `pip`.
+The cross-platform tool [colcon](https://colcon.readthedocs.io/en/released/) was chosen to simplify the
+build of the several mutually dependent [CMake](https://cmake.org/cmake/help/latest/) projects. In order to use
+colcon, [Python3](https://www.python.org/) and [CMake](https://cmake.org/cmake/help/latest/) must be first installed.
+Detailed instructions can be found in the
+[testing framework documentation](https://eprosima-discovery-server.readthedocs.io/en/latest/).
+
+The test suite is written in Python3 and needs the following modules, which can be installed using `pip`:
 
 ```bash
-pip3 install jsondiff==2.0.0 xmltodict==0.13.0 pandas==3.0.1 psutil
+pip3 install jsondiff==2.0.0 xmltodict==0.13.0 pandas==3.0.1 psutil xmlschema
 ```
 
-A [discovery-server.repos](https://raw.githubusercontent.com/eProsima/Discovery-Server/master/discovery-server.repos)
+A [discovery-server.repos](https://raw.githubusercontent.com/eProsima/Discovery-Server-Testing-Framework/master/discovery-server.repos)
 file is available in order to profit from [vcstool](https://github.com/dirk-thomas/vcstool) capabilities to download
 the needed repositories.
 
 ### Linux
 
-1.  Create a Discovery Server workspace and download the repos file that will be used to install the Discovery Server
-    tool and its dependencies:
+1.  Create a workspace and download the repos file that will be used to build the framework and its dependencies:
 
     ```bash
     $ mkdir -p discovery-server-ws/src && cd discovery-server-ws
-    $ wget https://raw.githubusercontent.com/eProsima/Discovery-Server/master/discovery-server.repos
+    $ wget https://raw.githubusercontent.com/eProsima/Discovery-Server-Testing-Framework/master/discovery-server.repos
     $ vcs import src < discovery-server.repos
     ```
 
-1.  Finally, use colcon to compile all software.
+1.  Use colcon to compile all software.
     Choose the build configuration by declaring ``CMAKE_BUILD_TYPE`` as Debug or Release.
-    For this example, the Debug option has been chosen, which would be the choice of advanced users for debugging purposes.
+    The `fastdds` CLI tool must be installed too, since part of the test cases drive it.
 
     ```bash
-    $ colcon build --base-paths src
-            \ --packages-up-to discovery-server
-            \ --cmake-args -DTHIRDPARTY=ON -DLOG_LEVEL_INFO=ON -DCOMPILE_EXAMPLES=ON -DINTERNALDEBUG=ON -DCMAKE_BUILD_TYPE=Debug
+    $ colcon build --base-paths src \
+            --packages-up-to discovery-server \
+            --cmake-args -DTHIRDPARTY=ON -DCOMPILE_TOOLS=ON -DINSTALL_TOOLS=ON \
+                    -DLOG_LEVEL_INFO=ON -DCMAKE_BUILD_TYPE=Debug
     ```
-
-1.  If you installed the Discovery Server tool following the steps outlined above, you can try the
-    *HelloWorldExampleDS*.
-    To run the example navigate to the following directory
-
-    ``<path/to/discovery-server-ws>/discovery-server-ws/install/discovery-server/examples/HelloWorldExampleDS``
-
-    and run
-
-    ```bash
-    $ ./HelloWorldExampleDS-d --help
-    ```
-
-    to display the example usage instructions.
-
-    In order to test the *HelloWorldExampleDS* open three terminals and run the above command.
-    Then run the following command in each terminal:
-    -   Terminal 1:
-        ```bash
-        $ cd <path/to/discovery-server-ws>/discovery-server-ws/install/discovery-server/examples/HelloWorldExampleDS
-        $ ./HelloWorldExampleDS publisher
-        ```
-    -   Terminal 2:
-        ```bash
-        $ cd <path/to/discovery-server-ws>/discovery-server-ws/install/discovery-server/examples/HelloWorldExampleDS
-        $ ./HelloWorldExampleDS subscriber
-        ```
-    -   Terminal 3:
-        ```bash
-        $ cd <path/to/discovery-server-ws>/discovery-server-ws/install/discovery-server/examples/HelloWorldExampleDS
-        $ ./HelloWorldExampleDS server
-        ```
 
 ### Windows
 
-1.  Create a Discovery Server workspace and download the repos file that will be used to install the Discovery Server
-    tool and its dependencies:
+1.  Create a workspace and download the repos file that will be used to build the framework and its dependencies:
 
     ```bat
     > mkdir discovery-server-ws
     > cd discovery-server-ws
     > mkdir src
-    > wget https://raw.githubusercontent.com/eProsima/Discovery-Server/master/discovery-server.repos
+    > wget https://raw.githubusercontent.com/eProsima/Discovery-Server-Testing-Framework/master/discovery-server.repos
     > vcs import src < discovery-server.repos
     ```
 
@@ -144,50 +109,19 @@ the needed repositories.
     Any console can be setup into a visual studio one by executing a batch file.
     For example, in VS2017 is usually ``C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat``
 
-1.  Finally, use colcon to compile all software.
-    Choose the build configuration by declaring ``CMAKE_BUILD_TYPE`` as Debug or Release.
-    For this example, the Debug option has been chosen, which would be the choice of advanced users for debugging purposes.
-    If using a multi-configuration generator like Visual Studio we recommend to build both in debug and release modes
+1.  Use colcon to compile all software.
+    If using a multi-configuration generator like Visual Studio we recommend to build both in debug and release modes.
 
     ```bat
-    > colcon build --base-paths src
-            \ --packages-up-to discovery-server
-            \ --cmake-args -DTHIRDPARTY=ON -DLOG_LEVEL_INFO=ON -DCOMPILE_EXAMPLES=ON -DINTERNALDEBUG=ON -DCMAKE_BUILD_TYPE=Debug
-    > colcon build --base-paths src
-            \ --packages-up-to discovery-server
-            \ --cmake-args -DTHIRDPARTY=ON -DCOMPILE_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release
+    > colcon build --base-paths src ^
+            --packages-up-to discovery-server ^
+            --cmake-args -DTHIRDPARTY=ON -DCOMPILE_TOOLS=ON -DINSTALL_TOOLS=ON ^
+                    -DLOG_LEVEL_INFO=ON -DCMAKE_BUILD_TYPE=Debug
+    > colcon build --base-paths src ^
+            --packages-up-to discovery-server ^
+            --cmake-args -DTHIRDPARTY=ON -DCOMPILE_TOOLS=ON -DINSTALL_TOOLS=ON ^
+                    -DCMAKE_BUILD_TYPE=Release
     ```
-
-1. If you installed the Discovery Server tool following the steps outlined above, you can try the
-    *HelloWorldExampleDS*.
-    To run the example navigate to the following directory
-
-    ``<path/to/discovery-server-ws>/discovery-server-ws/install/discovery-server/examples/HelloWorldExampleDS``
-
-    and run
-
-    ```bash
-    > HelloWorldExampleDS --help
-    ```
-
-    to display the example usage instructions.
-
-    In order to test the *HelloWorldExampleDS* open three terminals and run the above command.
-    Then run the following command in each terminal:
-    -   Terminal 1:
-        ```bash
-        > cd <path/to/discovery-server-ws>/discovery-server-ws/install/discovery-server/examples/HelloWorldExampleDS
-        > HelloWorldExampleDS publisher
-        ```
-    -   Terminal 2:
-        ```bash
-        > cd <path/to/discovery-server-ws>/discovery-server-ws/install/discovery-server/examples/HelloWorldExampleDS
-        > HelloWorldExampleDS subscriber
-        ```
-    -   Terminal 3:
-        ```bash
-        > cd <path/to/discovery-server-ws>/discovery-server-ws/install/discovery-server/examples/HelloWorldExampleDS
-        > HelloWorldExampleDS server
 
 ---
 **NOTE**
@@ -195,103 +129,105 @@ the needed repositories.
 In order to avoid using *vcstool*, the following repositories should be downloaded from github into
 the `discovery-server-ws/src` directory:
 
-|            PACKAGE                 |                              URL                        |    BRANCH   |
-|:-----------------------------------|:--------------------------------------------------------|:-----------:|
-| fastcdr:                           | https://github.com/eProsima/Fast-CDR.git                |    master   |
-| fastdds:                           | https://github.com/eProsima/Fast-DDS.git                |    master   |
-| discovery_server:                  | https://github.com/eProsima/Discovery-Server.git        |    master   |
-| foonathan_memory_vendor:           | https://github.com/eProsima/foonathan_memory_vendor.git |    master   |
-| leethomason/tinyxml2:              | https://github.com/leethomason/tinyxml2.git             |    master   |
+|          PACKAGE          |                                URL                                 |  BRANCH  |
+|:--------------------------|:-------------------------------------------------------------------|:--------:|
+| fastcdr                   | https://github.com/eProsima/Fast-CDR.git                           |  master  |
+| fastdds                   | https://github.com/eProsima/Fast-DDS.git                           |  master  |
+| discovery_server          | https://github.com/eProsima/Discovery-Server-Testing-Framework.git |  master  |
+| foonathan_memory_vendor   | https://github.com/eProsima/foonathan_memory_vendor.git            |  master  |
+| leethomason/tinyxml2      | https://github.com/leethomason/tinyxml2.git                        |  master  |
 
 ---
 
-## Usage
+## Running the tests
 
-### XML profiles
+Every test case is registered with CTest twice, once with the shared memory transport enabled and once with it
+disabled, under the name `discovery_server_test.<test_name>.SHM_[ON|OFF]`.
 
-Each setting in *Fast DDS* can be configured through XML profiles. XML profiles allows to avoid tiresome
-hard-coded settings within applications sources using XML configuration files.
-The *Fast DDS* XML schema was duly updated to accommodate the new Discovery Server tool settings.
+-   Run the whole suite with colcon:
 
--   The participant profile ``<builtin>`` tag contains a ``<discovery_config>`` tag where all discovery-related info is
-    gathered. This new tag contains the following new XML child elements:
-	- ``<discoveryProtocol>``: specifies the discovery type through the ``DiscoveryProtocol`` enumeration.
-	- ``<discoveryServersList>``: specifies the server or servers to which a Client/Server connects.
-	- ``<clientAnnouncementPeriod>``: specifies the time span between PDP metatraffic exchange.
+    ```bash
+    $ colcon test --base-paths src --packages-select discovery-server \
+            --event-handlers=console_direct+ --ctest-args --label-exclude xfail
+    ```
 
-An example of XML profiles for a client and a server is shown below.
+-   Or run it with CTest from the build directory.
+    Tests are independent from each other (each server uses its own set of ports), so they can be parallelized:
+
+    ```bash
+    $ cd build/discovery-server
+    $ ctest -j 10 --label-exclude xfail
+    ```
+
+    Tests labelled `xfail` are known to be leaky and may fail; CI excludes them.
+
+-   A single scenario can also be launched directly through the test runner, which is handy while debugging.
+    The tool binary and the `fastdds` CLI tool are passed as arguments:
+
+    ```bash
+    $ cd build/discovery-server/test
+    $ python3 run_test.py -e <path/to>/discovery-server-X.X.X \
+            -f <path/to>/fastdds \
+            -t test_01_trivial \
+            -s true -i false --debug --not-remove
+    ```
+
+    `-t` accepts several test names or a name pattern, `-s`/`-i` select the shared memory and intraprocess
+    configurations, and `--not-remove` keeps the files generated during the execution for inspection.
+
+Each process launched by a test case is checked by a set of validators declared in the test parameters file:
+
+-   `ground_truth_validation`: compares the generated snapshot with the expected one stored in `test_solutions`.
+-   `generate_validation`: compares the generated snapshot with one built on the fly from the test description.
+-   `count_lines_validation`: compares the number of lines of the generated and expected snapshots.
+-   `exit_code_validation` and `stderr_validation`: check the process exit code and its error output.
+
+## Test configuration files
+
+The tool is driven by an XML file whose outermost tag is `DS`, an extension of the *Fast DDS* XML schema that adds
+the tags needed to describe a test scenario:
+
+-   `profiles`: plain *Fast DDS* profiles, used to fine-tune the participants deployed by the tool.
+    Refer to the
+    [Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/xml_configuration/making_xml_profiles.html)
+    for further information on this element.
+-   `servers` and `clients`: the participants to deploy, each one with its `creation_time`, `removal_time` and the
+    `publisher` and `subscriber` endpoints it must create.
+-   `snapshots`: the instants at which the discovery database must be dumped, and the file where the results are
+    written.
+
+The `DS` tag admits a `user_shutdown` attribute that defaults to *true*. Test XML files set
+`user_shutdown="false"`, which makes the tool close as soon as the described scenario is fulfilled.
+
+A trivial example, taken from the test suite:
 
 ```xml
-<participant profile_name="UDP_client" >
-  <rtps>
-	<builtin>
-		<discovery_config>
-		  <discoveryProtocol>CLIENT</discoveryProtocol>
-		  <discoveryServersList>
-			<RemoteServer prefix="4d.49.47.55.45.4c.5f.42.41.52.52.4f">
-			  <metatrafficUnicastLocatorList>
-				<locator>
-				  <udpv4>
-					<address>192.168.1.113</address>
-					<port>64863</port>
-				  </udpv4>
-				</locator>
-			  </metatrafficUnicastLocatorList>
-			</RemoteServer>
-		  </discoveryServersList>
-		</discovery_config>
-	</builtin>
-  </rtps>
-</participant>
-
-<participant profile_name="UDP_server">
-  <rtps>
-	<prefix>4d.49.47.55.45.4c.5f.42.41.52.52.4f</prefix>
-	<builtin>
-		<discovery_config>
-		  <discoveryProtocol>SERVER</discoveryProtocol>
-		</discovery_config>
-		<metatrafficUnicastLocatorList>
-			<locator>
-				<udpv4>
-					<address>192.168.1.113</address>
-					<port>64863</port>
-				</udpv4>
-			</locator>
-		</metatrafficUnicastLocatorList>
-	</builtin>
-  </rtps>
-</participant>
+<DS xmlns="http://www.eprosima.com/XMLSchemas/discovery-server" user_shutdown="false">
+  <servers>
+    <server name="server" profile_name="UDP server" />
+  </servers>
+  <clients>
+    <client name="client1" profile_name="UDP client"/>
+    <client name="client2" profile_name="UDP client"/>
+  </clients>
+  <snapshots file="./snapshots.xml">
+    <snapshot time="3">Check the clients met the server and know each other</snapshot>
+  </snapshots>
+  <profiles>
+    <!-- Fast DDS participant profiles referenced above -->
+  </profiles>
+</DS>
 ```
 
-### Discovery Server executable
-
-The discovery server binary (named after the pattern ``discovery-server-X.X.X(d)`` where ``X.X.X`` is the version
-number and the optional *d* denotes a debug build) is set up from one XML profiles files passed as command-line
-arguments.
-To have the tool accessible in the terminal session it is necessary to source the setup file.
-
--   Linux
-    ```bash
-    $ source <path/to/discovery-server-ws>/discovery-server-ws/install/setup.bash
-    $ discovery-server-X.X.X(d) -c config_file.xml
-    ```
-
--   Windows
-
-    ```bat
-    > . <path/to/discovery-server-ws>/discovery-server-ws/install/setup.bat
-    > discovery-server-X.X.X(d).exe config_file.xml
-    ```
+More examples are available under `resources/xml/examples` and `test/configuration/test_cases`, and the full
+description of every tag is available in the
+[testing framework documentation](https://eprosima-discovery-server.readthedocs.io/en/latest/).
 
 ## Documentation
 
-You can access the documentation online, which is hosted on
-[Read the Docs](https://eprosima-discovery-server.readthedocs.io/en/latest/).
+The documentation of this testing framework is hosted on
+[Read the Docs](https://eprosima-discovery-server.readthedocs.io/en/latest/), and its sources are kept in the
+[Discovery-Server-Testing-Framework-docs repository](https://github.com/eProsima/Discovery-Server-Testing-Framework-docs).
 
-<!-- * [Start Page](https://eprosima-discovery-server.readthedocs.io/en/latest/)
-* [Installation manual](https://eprosima-discovery-server.readthedocs.io/en/latest/installation.html)
-* [User manual](https://eprosima-discovery-server.readthedocs.io/en/latest/command_line.html)
-* [Examples](https://eprosima-discovery-server.readthedocs.io/en/latest/HelloWorldExample.html)
-* [Tests](https://eprosima-discovery-server.readthedocs.io/en/latest/tests.html)
-* [Release notes](https://eprosima-discovery-server.readthedocs.io/en/latest/notes.html) -->
+The documentation of the Discovery Server discovery mechanism itself is part of the
+[Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/discovery/discovery.html).

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -1,20 +1,21 @@
 # Release support
 
 
-Please, refer to the [master branch](https://github.com/eProsima/Discovery-Server/blob/master/RELEASE_SUPPORT.md) for the latest version of this document.
+Please, refer to the [master branch](https://github.com/eProsima/Discovery-Server-Testing-Framework/blob/master/RELEASE_SUPPORT.md) for the latest version of this document.
 
-*eProsima Fast DDS Discovery Server* maintains several releases with different support cycles.
-**All of them are attached to different *eProsima Fast DDS* releases.**
+The *Discovery Server testing framework* maintains several releases with different support cycles.
+**Each of them is attached to a different *eProsima Fast DDS* release**, since every branch tests the Discovery Server
+discovery mechanism as shipped by that *Fast DDS* version.
 
-## *eProsima Fast DDS* and *Discovery Server* version compatibility
+## *eProsima Fast DDS* and testing framework version compatibility
 
-|Fast DDS Version|Discovery Server Version|Discovery Server Latest Release|
+|Fast DDS Version|Testing Framework Version|Testing Framework Latest Release|
 |----------------|------------------------|-------------------------------|
-|3.5|2.3.0|[v2.3.0](https://github.com/eProsima/Discovery-Server/releases/tag/v2.3.0)|
-|3.4|2.2.0|[v2.2.0](https://github.com/eProsima/Discovery-Server/releases/tag/v2.2.0)|
-|3.3|2.1.0|[v2.1.0](https://github.com/eProsima/Discovery-Server/releases/tag/v2.1.0)|
-|3.2|2.0.1|[v2.0.1](https://github.com/eProsima/Discovery-Server/releases/tag/v2.0.1)|
-|2.14|1.2.2|[v1.2.2](https://github.com/eProsima/Discovery-Server/releases/tag/v1.2.2)|
-|2.6|1.2.1|[v1.2.1](https://github.com/eProsima/Discovery-Server/releases/tag/v1.2.1)|
+|3.5|2.3.0|[v2.3.0](https://github.com/eProsima/Discovery-Server-Testing-Framework/releases/tag/v2.3.0)|
+|3.4|2.2.0|[v2.2.0](https://github.com/eProsima/Discovery-Server-Testing-Framework/releases/tag/v2.2.0)|
+|3.3|2.1.0|[v2.1.0](https://github.com/eProsima/Discovery-Server-Testing-Framework/releases/tag/v2.1.0)|
+|3.2|2.0.1|[v2.0.1](https://github.com/eProsima/Discovery-Server-Testing-Framework/releases/tag/v2.0.1)|
+|2.14|1.2.2|[v1.2.2](https://github.com/eProsima/Discovery-Server-Testing-Framework/releases/tag/v1.2.2)|
+|2.6|1.2.1|[v1.2.1](https://github.com/eProsima/Discovery-Server-Testing-Framework/releases/tag/v1.2.1)|
 
 For detailed information about the lifecycle of the different *Fast DDS* versions (and their corresponding counterpart in this repository), please refer to the [release support section of the Fast DDS repository](https://github.com/eProsima/Fast-DDS/blob/master/RELEASE_SUPPORT.md).


### PR DESCRIPTION
## Description

Reframes the repository documentation so that it covers only the **Discovery Server testing framework**, and points to the [Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/discovery/discovery.html) for the Discovery Server discovery mechanism itself, which is a feature of Fast DDS.

**`README.md`** rewritten:

- New framing: the repository hosts the testing framework, and the feature documentation lives in the Fast DDS docs.
- New sections describing the two parts of the framework (the `discovery-server` tool and the CTest/Python test suite), how to run the suite, and the structure of the XML test configuration files.
- Build instructions corrected along the way: dropped `-DCOMPILE_EXAMPLES` and `-DINTERNALDEBUG` (no longer CMake options of this project) and the `HelloWorldExampleDS` walkthrough (the example is no longer part of the repository); added `-DCOMPILE_TOOLS=ON -DINSTALL_TOOLS=ON`, since several test cases drive the `fastdds` CLI tool; the pip module list now matches what CI installs.
- GitHub URLs updated to the current repository names.

**`RELEASE_SUPPORT.md`**: the compatibility table is now expressed as testing framework versions attached to Fast DDS releases.

## Contributor Checklist

- [x] Commit messages follow the project guidelines.
- _N/A_ The added tests pass locally.
- [x] Changes are backwards compatible.
- [x] New feature has been documented/Current behavior is correctly described in the documentation.
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.